### PR TITLE
Update index.js

### DIFF
--- a/v2/index.js
+++ b/v2/index.js
@@ -4,7 +4,7 @@ import { Validator } from "jsonschema";
 import { schema } from "../templates/base-template_schema.js";
 
 const BACKEND_URL = process.env?.REACT_APP_NHOST_BACKEND_URL 
-	? `${process.env.REACT_APP_NHOST_BACKEND_URL}/${process.env.REACT_APP_NHOST_VERSION}/${process.env.REACT_APP_NHOST_ENDPOINT}`;
+	? `${process.env.REACT_APP_NHOST_BACKEND_URL}/${process.env.REACT_APP_NHOST_VERSION}/${process.env.REACT_APP_NHOST_ENDPOINT}`
 	: `${process.env.VITE_NHOST_BACKEND_URL}/${process.env.VITE_NHOST_VERSION}/${process.env.VITE_NHOST_ENDPOINT}`;
 
 const header = {

--- a/v2/index.js
+++ b/v2/index.js
@@ -3,7 +3,10 @@ import { prepareQuery } from "../templates/base-template.js";
 import { Validator } from "jsonschema";
 import { schema } from "../templates/base-template_schema.js";
 
-const BACKEND_URL = `${process.env.REACT_APP_NHOST_BACKEND_URL}/${process.env.REACT_APP_NHOST_VERSION}/${process.env.REACT_APP_NHOST_ENDPOINT}`;
+const BACKEND_URL = process.env?.REACT_APP_NHOST_BACKEND_URL 
+	? `${process.env.REACT_APP_NHOST_BACKEND_URL}/${process.env.REACT_APP_NHOST_VERSION}/${process.env.REACT_APP_NHOST_ENDPOINT}`;
+	: `${process.env.VITE_NHOST_BACKEND_URL}/${process.env.VITE_NHOST_VERSION}/${process.env.VITE_NHOST_ENDPOINT}`;
+
 const header = {
   headers: {
     "Content-Type": "application/json",


### PR DESCRIPTION
Permit use of the process.env variable via Vitejs if the user doesn't use Cra.
ViteJs need a variable starting with VITE_ to be able to use it.
 Even if we normally need to use import.meta.env with Vite, the developer can do the necessary job to react here. But the correct process.env variable need to be on reach on json-graphql-parser.